### PR TITLE
Style the error modal

### DIFF
--- a/SCDPatientApp/screens/DailyDiaryFormScreen.tsx
+++ b/SCDPatientApp/screens/DailyDiaryFormScreen.tsx
@@ -11,6 +11,7 @@ import {
   Modal,
 } from "native-base";
 import { observer } from "mobx-react-lite";
+import { WarningIcon } from "native-base";
 
 import { RootStackScreenProps } from "../models/navigation";
 import styles from "../styles/DailyDiaryFormScreen.styles";
@@ -181,27 +182,19 @@ const DailyDiaryFormScreen = observer(
 
     return (
       <>
-        <Modal isOpen={showSuccessModal} onClose={closeSuccessModal} size="lg">
-          <Modal.Content maxWidth="350">
-            <Modal.CloseButton />
-            <Modal.Header>Success!</Modal.Header>
-            <Modal.Body>
-              <VStack space={3}>
-                <HStack alignItems="center" justifyContent="space-between">
-                  <Text>We have recorded your diary entry.</Text>
-                </HStack>
-              </VStack>
-            </Modal.Body>
-          </Modal.Content>
-        </Modal>
         <Modal isOpen={showErrorModal} onClose={closeErrorModal} size="lg">
           <Modal.Content maxWidth="350">
             <Modal.CloseButton />
-            <Modal.Header>Error</Modal.Header>
+            <Modal.Header>
+              <HStack>
+                <WarningIcon style={{color: Colors.darkColor}} />
+                <Text style={[styles.cardText, {marginLeft: 10}]}>Error</Text>
+              </HStack>
+            </Modal.Header>
             <Modal.Body>
               <VStack space={3}>
                 <HStack alignItems="center" justifyContent="space-between">
-                  <Text>{errorMsg}</Text>
+                  <Text style={styles.errorModalText}>{errorMsg}</Text>
                 </HStack>
               </VStack>
             </Modal.Body>

--- a/SCDPatientApp/styles/DailyDiaryFormScreen.styles.ts
+++ b/SCDPatientApp/styles/DailyDiaryFormScreen.styles.ts
@@ -60,6 +60,13 @@ const styles = StyleSheet.create({
     marginTop: 26,
   },
 
+  errorModalText: {
+    fontFamily: "Poppins-Medium",
+    fontWeight: "500",
+    fontSize: 14,
+    marginBottom: 30
+  },
+
   firstQuestion: {
     marginTop: 17,
   },


### PR DESCRIPTION
![Screen Shot 2021-11-24 at 2 25 16 AM](https://user-images.githubusercontent.com/36581058/143193321-2c4785ed-0b58-4397-a001-a304f487b328.png)


Updated styling of the error modal. Removed the success modal for now, as the styling is TBD and will likely be something on the HomeScreen.